### PR TITLE
Improvements - Efficiency and robustness across all Alpine.js patterns

### DIFF
--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -599,6 +599,10 @@
 
       handleInputKeydown(event) {
         if (event.key === 'Enter') {
+          if (event.target instanceof HTMLTextAreaElement) {
+            return
+          }
+
           event.preventDefault()
           this.commitChanges()
 

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -840,8 +840,16 @@
       menuItemIds: [],
       triggerRefName: initialConfig.triggerRef ?? 'dropdownTrigger',
 
-      normalizeMenuItems(rawMenuItems, itemDepth = 0) {
+      normalizeMenuItems(rawMenuItems, itemDepth = 0, maxDepth = 5) {
         if (!Array.isArray(rawMenuItems)) {
+          return []
+        }
+
+        if (itemDepth > maxDepth) {
+          console.error(
+            `[huxDropdown] normalizeMenuItems exceeded maxDepth of ${maxDepth} — check for circular children references`,
+          )
+
           return []
         }
 
@@ -869,7 +877,11 @@
                 ]
               : []
 
-          const normalizedChildren = this.normalizeMenuItems(rawMenuItem.children, itemDepth + 1)
+          const normalizedChildren = this.normalizeMenuItems(
+            rawMenuItem.children,
+            itemDepth + 1,
+            maxDepth,
+          )
 
           return [...normalizedItem, ...normalizedChildren]
         })

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -444,6 +444,12 @@
       },
 
       async copyToClipboard() {
+        if (!navigator.clipboard) {
+          console.error('[huxCopy] Clipboard API unavailable — requires a secure context')
+
+          return
+        }
+
         try {
           const contentToCopy = this.resolveCopyContent()
 

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -256,10 +256,15 @@
       paletteId: initialConfig.paletteId ?? null,
       shortcutKey: (initialConfig.shortcutKey ?? 'k').toLowerCase(),
       shortcutHint: '',
+      _paletteItemMap: null,
 
       init() {
         this.paletteItems = this.paletteItems.filter(
           (paletteItem) => paletteItem?.label && (paletteItem?.href || paletteItem?.action),
+        )
+
+        this._paletteItemMap = new Map(
+          this.paletteItems.map((paletteItem) => [paletteItem.label, paletteItem]),
         )
 
         const uppercaseShortcutKey = this.shortcutKey.toUpperCase()
@@ -295,7 +300,7 @@
       },
 
       findPaletteItem(itemLabel) {
-        return this.paletteItems.find((paletteItem) => paletteItem.label === itemLabel) ?? null
+        return this._paletteItemMap?.get(itemLabel) ?? null
       },
 
       resolveActionEventName(rawEventName) {

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -1261,6 +1261,7 @@
       intersectionObserver: null,
       observedHeadingElements: [],
       scrollContainerScrollHandler: null,
+      _scrollRafPending: false,
       templateRefName: initialConfig.templateRef ?? 'tocContent',
       headingSelector: initialConfig.headingSelector ?? 'h2, h3, h4, h5, h6',
 
@@ -1370,17 +1371,27 @@
       },
 
       handleScrollContainerPosition() {
-        if (!this.scrollContainerElement || this.headingItems.length === 0) {
+        if (this._scrollRafPending) {
           return
         }
 
-        const reachedBottomOfContainer =
-          this.scrollContainerElement.scrollTop + this.scrollContainerElement.clientHeight >=
-          this.scrollContainerElement.scrollHeight - 2
+        this._scrollRafPending = true
 
-        if (reachedBottomOfContainer) {
-          this.activeHeadingId = this.headingItems[this.headingItems.length - 1].id
-        }
+        requestAnimationFrame(() => {
+          this._scrollRafPending = false
+
+          if (!this.scrollContainerElement || this.headingItems.length === 0) {
+            return
+          }
+
+          const reachedBottomOfContainer =
+            this.scrollContainerElement.scrollTop + this.scrollContainerElement.clientHeight >=
+            this.scrollContainerElement.scrollHeight - 2
+
+          if (reachedBottomOfContainer) {
+            this.activeHeadingId = this.headingItems[this.headingItems.length - 1].id
+          }
+        })
       },
 
       destroy() {

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -829,6 +829,7 @@
       menuId: null,
       triggerButtonId: null,
       menuItemIds: [],
+      triggerRefName: initialConfig.triggerRef ?? 'dropdownTrigger',
 
       normalizeMenuItems(rawMenuItems, itemDepth = 0) {
         if (!Array.isArray(rawMenuItems)) {
@@ -889,7 +890,7 @@
         this.focusedIndex = -1
 
         if (restoreFocus) {
-          this.$nextTick(() => this.$refs.dropdownTrigger?.focus())
+          this.$nextTick(() => this.$refs[this.triggerRefName]?.focus())
         }
       },
 

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -1054,6 +1054,7 @@
 
       init() {
         if (this.maxWidth !== null && this.maxWidth < this.minWidth) {
+          console.warn('[huxResizable] maxWidth cannot be less than minWidth, clamping to minWidth')
           this.maxWidth = this.minWidth
         }
 

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -239,8 +239,7 @@
       },
 
       getLabelForValue(selectedValue) {
-        const normalizedOptionItems = Array.isArray(this.optionItems) ? this.optionItems : []
-        const matchedOptionItem = normalizedOptionItems.find(
+        const matchedOptionItem = this.optionItems.find(
           (optionItem) => optionItem.value === selectedValue,
         )
 

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -1125,6 +1125,8 @@
           return
         }
 
+        this._onDragEnd()
+
         pointerEvent.preventDefault()
 
         if (pointerEvent.type === 'mousedown') {

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -761,8 +761,7 @@
             (focusableElement) =>
               focusableElement.tabIndex >= 0 &&
               !focusableElement.hasAttribute('disabled') &&
-              focusableElement.getAttribute('aria-hidden') !== 'true' &&
-              focusableElement.getClientRects().length > 0,
+              focusableElement.getAttribute('aria-hidden') !== 'true',
           )
       },
 

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -1567,6 +1567,7 @@
       tabItems: [],
       useHash: initialConfig.useHash ?? false,
       tabsId: initialConfig.id ?? null,
+      _tabElements: null,
 
       init() {
         this.tabItems = (initialConfig.tabItems ?? []).filter(
@@ -1593,11 +1594,15 @@
           this.activeTabId = this.tabItems.length > 0 ? this.tabItems[0].id : null
         }
 
-        if (this.tabsId) {
-          // Defer initial event so all huxTabPanel instances in the current render
-          // have had a chance to register their window listeners in init().
-          this.$nextTick(() => this._dispatchChangeEvent())
-        }
+        this.$nextTick(() => {
+          this._tabElements = [...this.$el.querySelectorAll('[role="tab"]')]
+
+          if (this.tabsId) {
+            // Defer initial event so all huxTabPanel instances in the current render
+            // have had a chance to register their window listeners in init().
+            this._dispatchChangeEvent()
+          }
+        })
       },
 
       get activeTabIndex() {
@@ -1641,15 +1646,11 @@
       },
 
       focusTab(tabId) {
-        this.$nextTick(() => {
-          const tabIndex = this.findTabIndex(tabId)
+        const tabIndex = this.findTabIndex(tabId)
 
-          if (tabIndex === -1) return
+        if (tabIndex === -1) return
 
-          const tabElements = this.$el.querySelectorAll('[role="tab"]')
-
-          tabElements[tabIndex]?.focus()
-        })
+        this._tabElements?.[tabIndex]?.focus()
       },
 
       focusNextTab() {

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -1839,7 +1839,7 @@
     Alpine.data('huxTabPanel', (initialConfig = {}) => ({
       tabsId: initialConfig.tabsId ?? null,
       tabId: initialConfig.tabId ?? null,
-      isActive: false,
+      isActive: initialConfig.startsActive ?? false,
       _changeHandler: null,
 
       init() {

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -1655,11 +1655,13 @@
       rootMargin: initialConfig.rootMargin ?? '0px',
       loaderTemplateRefName: initialConfig.loaderRef ?? 'infiniteScrollLoader',
       useContainerRoot: initialConfig.useContainerRoot ?? false,
+      loadTimeout: initialConfig.loadTimeout ?? 5000,
       isLoading: false,
       isDisabled: initialConfig.startsDisabled ?? false,
 
       _scrollObserver: null,
       _loaderElement: null,
+      _loadTimeoutId: null,
 
       init() {
         this.$nextTick(() => {
@@ -1705,9 +1707,30 @@
       _dispatchLoadMoreEvent() {
         this.isLoading = true
 
+        if (this.loadTimeout > 0) {
+          this._loadTimeoutId = setTimeout(() => {
+            if (this.isLoading) {
+              this.isLoading = false
+              console.warn(
+                '[huxInfiniteScroll] Load timed out — markComplete or markFailed was not called',
+              )
+            }
+
+            this._loadTimeoutId = null
+          }, this.loadTimeout)
+        }
+
+        const clearLoadTimeout = () => {
+          if (this._loadTimeoutId !== null) {
+            clearTimeout(this._loadTimeoutId)
+            this._loadTimeoutId = null
+          }
+        }
+
         const detail = {
           scrollerId: this.scrollerId,
           markComplete: (hasMore = true) => {
+            clearLoadTimeout()
             this.isLoading = false
 
             if (!hasMore) {
@@ -1715,6 +1738,7 @@
             }
           },
           markFailed: () => {
+            clearLoadTimeout()
             this.isLoading = false
           },
         }
@@ -1747,6 +1771,11 @@
       },
 
       destroy() {
+        if (this._loadTimeoutId !== null) {
+          clearTimeout(this._loadTimeoutId)
+          this._loadTimeoutId = null
+        }
+
         if (this._scrollObserver) {
           this._scrollObserver.disconnect()
           this._scrollObserver = null

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -1282,11 +1282,13 @@
 
         this.scrollContainerElement = scrollContainerElement
 
-        const headingElements = scrollContainerElement.querySelectorAll(this.headingSelector)
+        const headingElements = Array.from(
+          scrollContainerElement.querySelectorAll(this.headingSelector),
+        )
 
-        this.observedHeadingElements = Array.from(headingElements)
+        this.observedHeadingElements = headingElements
 
-        this.headingItems = Array.from(headingElements).map((headingElement, headingIndex) => {
+        this.headingItems = headingElements.map((headingElement, headingIndex) => {
           const headingId = this.ensureHeadingElementId(headingElement, headingIndex)
 
           return {

--- a/src/components/PatternRegistration.astro
+++ b/src/components/PatternRegistration.astro
@@ -16,23 +16,33 @@
       focusedIndex: -1,
       comboboxInputId: null,
       listboxId: null,
-      optionItems: initialConfig.optionItems ?? [],
+      optionItems: [],
       inputTemplateRefName: initialConfig.inputTemplateRef ?? 'comboboxInput',
       listboxTemplateRefName: initialConfig.listboxTemplateRef ?? 'comboboxListbox',
 
       init() {
+        const rawOptionItems = Array.isArray(initialConfig.optionItems)
+          ? initialConfig.optionItems
+          : []
+
+        this.optionItems = rawOptionItems.filter(
+          (optionItem) =>
+            optionItem &&
+            typeof optionItem.label === 'string' &&
+            typeof optionItem.value === 'string',
+        )
+
         this.configureTemplateRefs()
       },
 
       get filteredOptionItems() {
-        const normalizedOptionItems = Array.isArray(this.optionItems) ? this.optionItems : []
         const normalizedSearchQuery = this.searchQuery.trim().toLowerCase()
 
         if (this.hideOptionItemsWhenSearchQueryEmpty && normalizedSearchQuery === '') {
           return []
         }
 
-        return normalizedOptionItems
+        return this.optionItems
           .map((optionItem, sourceIndex) => ({ optionItem, sourceIndex }))
           .filter(({ optionItem }) =>
             optionItem.label.toLowerCase().includes(normalizedSearchQuery),

--- a/src/content/patterns/combobox.mdx
+++ b/src/content/patterns/combobox.mdx
@@ -10,7 +10,7 @@ terms:
   - keyboard-navigation
   - multiselect
 pubDate: 2026-04-20
-modDate: 2026-05-06
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/Combobox.astro'

--- a/src/content/patterns/command-palette.mdx
+++ b/src/content/patterns/command-palette.mdx
@@ -10,7 +10,7 @@ terms:
   - dialog
   - combobox
 pubDate: 2026-04-20
-modDate: 2026-04-21
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/CommandPalette.astro'

--- a/src/content/patterns/copy-to-clipboard.mdx
+++ b/src/content/patterns/copy-to-clipboard.mdx
@@ -118,6 +118,7 @@ huxCopy({
 
 ## Error Handling
 
+- If `navigator.clipboard` is unavailable (insecure context), the component logs `[huxCopy] Clipboard API unavailable — requires a secure context` and exits without writing. Clipboard writes require HTTPS or `localhost`.
 - If both `sourceNames` and `valueSourceNames` are empty, the component logs:
   `[huxCopy] No sourceNames or valueSourceNames configured`
 - If a configured source is missing, the component logs a source-specific lookup error.

--- a/src/content/patterns/copy-to-clipboard.mdx
+++ b/src/content/patterns/copy-to-clipboard.mdx
@@ -10,7 +10,7 @@ terms:
   - data-attributes
   - ux-pattern
 pubDate: 2026-04-20
-modDate: 2026-04-20
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/CopyToClipboard.astro'

--- a/src/content/patterns/dropdown.mdx
+++ b/src/content/patterns/dropdown.mdx
@@ -10,7 +10,7 @@ terms:
   - menu-button
   - action-dispatch
 pubDate: 2026-04-20
-modDate: 2026-04-21
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/Dropdown.astro'

--- a/src/content/patterns/dropdown.mdx
+++ b/src/content/patterns/dropdown.mdx
@@ -54,6 +54,8 @@ _Internal helper methods are private implementation details and are not part of 
 
 - `menuItems: Array<{ label: string, href?: string, action?: string, target?: string, children?: Array<{ label: string, href?: string, action?: string, target?: string }> }>` (default: `[]`)
 - `triggerId: string` (optional, scopes generated ids and action event names)
+- `triggerRef: string` (default: `'dropdownTrigger'`)
+  `x-ref` name used to restore focus to the trigger button when `closeMenu(true)` is called.
 
 _Use hyphen-case for action names. Non-hyphen-case names will be ignored._
 

--- a/src/content/patterns/infinite-scroll.mdx
+++ b/src/content/patterns/infinite-scroll.mdx
@@ -63,6 +63,8 @@ The `load-more` event `detail` object includes:
   Passed to the internal `IntersectionObserver`.
 - `startsDisabled: boolean` (default: `false`)
   Starts the component in a disabled state without observing the loader element.
+- `loadTimeout: number` (default: `5000`)
+  Milliseconds before `isLoading` is auto-reset if neither `markComplete` nor `markFailed` has been called. Set to `0` to disable the timeout.
 
 ## Quick Start
 
@@ -186,7 +188,7 @@ Use `.window` to listen for the event on the `window` object from any element:
 ## Error Handling
 
 - If `loaderRef` does not resolve to an `x-ref`, the component logs `[huxInfiniteScroll] Missing x-ref target for loaderRef: ${this.loaderTemplateRefName}` and exits initialization without throwing.
-- If the consumer does not call `detail.markComplete()` or `detail.markFailed()`, `isLoading` stays `true` indefinitely and no further events are fired. Always resolve or reject the callback.
+- If the consumer does not call `detail.markComplete()` or `detail.markFailed()` within `loadTimeout` milliseconds, `isLoading` is auto-reset to `false` and the component logs `[huxInfiniteScroll] Load timed out — markComplete or markFailed was not called`. Set `loadTimeout: 0` to disable the timeout and manage `isLoading` manually.
 
 ## Accessibility Notes
 

--- a/src/content/patterns/infinite-scroll.mdx
+++ b/src/content/patterns/infinite-scroll.mdx
@@ -10,7 +10,7 @@ terms:
   - load-more
   - virtual-list
 pubDate: 2026-06-06
-modDate: 2026-06-06
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/InfiniteScroll.astro'

--- a/src/content/patterns/inline-editor.mdx
+++ b/src/content/patterns/inline-editor.mdx
@@ -148,7 +148,7 @@ _Internal helper methods are private implementation details and are not part of 
 - `enterEditMode()` copies `inputValue` into `draftValue`, sets `isEditing = true`, focuses the configured input ref, and selects all text.
 - `registerInput()` stores the active input/textarea element, focuses it, and selects all text.
 - `handleInputFocus()` selects all text in the focused input/textarea.
-- `handleInputKeydown()` commits on `Enter` and reverts on `Escape`.
+- `handleInputKeydown()` commits on `Enter` (for `<input>` elements only — `<textarea>` elements allow normal newline insertion) and reverts on `Escape`.
 - `trapFocus()` cycles `Tab` and `Shift+Tab` inside the active focus-trap root while editing.
 - `commitChanges()` sets `inputValue = draftValue`, exits edit mode, restores focus (previous active element, configured return-focus ref, or first visible focusable element in DOM order), and dispatches commit event(s).
 - `revertChanges()` resets `draftValue = inputValue`, exits edit mode, restores focus (previous active element, configured return-focus ref, or first visible focusable element in DOM order), and dispatches revert event(s).

--- a/src/content/patterns/inline-editor.mdx
+++ b/src/content/patterns/inline-editor.mdx
@@ -10,7 +10,7 @@ terms:
   - focus-trap
   - ux-pattern
 pubDate: 2026-05-21
-modDate: 2026-05-23
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/InlineEditor.astro'

--- a/src/content/patterns/resizable.mdx
+++ b/src/content/patterns/resizable.mdx
@@ -10,7 +10,7 @@ terms:
   - iframe-preview
   - responsive-testing
 pubDate: 2026-04-20
-modDate: 2026-05-06
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/Resizable.astro'

--- a/src/content/patterns/scroll-spy.mdx
+++ b/src/content/patterns/scroll-spy.mdx
@@ -10,7 +10,7 @@ terms:
   - heading-navigation
   - documentation-navigation
 pubDate: 2026-04-20
-modDate: 2026-04-20
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/ScrollSpy.astro'

--- a/src/content/patterns/tabs.mdx
+++ b/src/content/patterns/tabs.mdx
@@ -67,6 +67,8 @@ Returns an Alpine data object for a decoupled tab panel with:
 
 - `tabsId: string` (required; matches the `id` passed to `huxTabs`)
 - `tabId: string` (required; the tab id this panel belongs to)
+- `startsActive: boolean` (default: `false`)
+  Sets the initial `isActive` state before the first `hux-tabs:{tabsId}:change` event fires. Use this on the panel that corresponds to the initial active tab to avoid a brief hidden-panel flash on first render.
 
 ## Quick Start
 

--- a/src/content/patterns/tabs.mdx
+++ b/src/content/patterns/tabs.mdx
@@ -10,7 +10,7 @@ terms:
   - roving-tabindex
   - hash-routing
 pubDate: 2026-04-20
-modDate: 2026-05-06
+modDate: 2026-06-09
 ---
 
 import Demo from '../../components/demos/Tabs.astro'


### PR DESCRIPTION
## Summary

- 15 targeted improvements across 10 Alpine.js patterns in `PatternRegistration.astro`, each committed individually
- Covers both **robustness** fixes (runtime throws, silent failures, hung state) and **efficiency** fixes (redundant DOM queries, reflows, repeated normalization)
- `modDate` updated on all 9 affected pattern MDX files

## Changes by pattern

**huxCombobox** — validate `optionItems` shape in `init()` to prevent runtime throws on malformed items; remove now-redundant `Array.isArray` guards from `filteredOptionItems` and `getLabelForValue`

**huxCommandPalette** — replace `Array.find` scan with a `Map` lookup in `findPaletteItem` built once after `init()`

**huxCopy** — guard against `navigator.clipboard` being unavailable in insecure contexts before attempting write

**huxInlineEditor** — skip Enter-key commit when the target is a `<textarea>` to preserve newline insertion; remove `getClientRects()` reflow from focus trap filter

**huxDropdown** — make the trigger ref name configurable via `triggerRef` option so focus restoration works with any ref name; add `maxDepth` guard to `normalizeMenuItems` to prevent infinite recursion on circular config

**huxResizable** — call `_onDragEnd()` at the top of `startDrag` to clean up any in-flight listeners before starting a new drag; warn when `maxWidth` is silently clamped to `minWidth`

**huxScrollSpy** — convert `NodeList` to array once and reuse for both `observedHeadingElements` and `headingItems`; throttle scroll handler with a `requestAnimationFrame` gate

**huxInfiniteScroll** — add configurable `loadTimeout` option (default 5000ms) that auto-resets `isLoading` and warns if `markComplete`/`markFailed` is never called

**huxTabs** — cache `[role="tab"]` elements after `init()` instead of re-querying on every keyboard navigation call

**huxTabPanel** — add `startsActive` option to set initial `isActive` state before the first `change` event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)