### PR TITLE
Bugfix - Fix Dropdown keyboard focus and hover/tabindex coupling

### DIFF
--- a/src/components/demos/Dropdown.astro
+++ b/src/components/demos/Dropdown.astro
@@ -108,7 +108,6 @@
                 role="menuitem"
                 class="flex items-center justify-between gap-3 py-2 pr-4 text-sm text-gray-700 hover:bg-gray-100 focus:bg-gray-100 focus:ring-2 focus:ring-blue-500 focus:outline-none focus:ring-inset"
                 x-on:click="selectItem(menuItem)"
-                x-on:mouseenter="focusedIndex = menuIndex"
                 x-on:focus="focusedIndex = menuIndex"
               >
                 <span x-text="menuItem.label"></span>
@@ -137,7 +136,6 @@
                 role="menuitem"
                 class="flex w-full items-center justify-between gap-3 py-2 pr-4 text-left text-sm text-gray-700 hover:bg-gray-100 focus:bg-gray-100 focus:ring-2 focus:ring-blue-500 focus:outline-none focus:ring-inset"
                 x-on:click="selectItem(menuItem)"
-                x-on:mouseenter="focusedIndex = menuIndex"
                 x-on:focus="focusedIndex = menuIndex"
               >
                 <span x-text="menuItem.label"></span>

--- a/src/components/patterns/huxDropdown.js
+++ b/src/components/patterns/huxDropdown.js
@@ -93,6 +93,7 @@ document.addEventListener('alpine:init', () => {
       }
 
       this.openMenu()
+      this.focusFirstItem()
     },
 
     focusItem(itemIndex) {

--- a/src/content/patterns/dropdown.mdx
+++ b/src/content/patterns/dropdown.mdx
@@ -194,6 +194,7 @@ if (menuItem?.target === '_blank') {
 - Nested entries are flattened into `menuItems` in depth-first order with `itemDepth` preserved for rendering and `parentLabel` set to the immediate parent's label (`null` for top-level entries).
 - Generated ids are based on `triggerId` when provided; otherwise a random uuid suffix is used.
 - `closeMenu(true)` restores focus to the trigger button on next tick.
+- `toggleMenu()` focuses the first menu item when it opens the menu; `openMenu()` alone does not move focus, so callers driving focus explicitly (for example Up/Down keydown handlers) can call `openMenu()` directly.
 - `focusNextItem()` and `focusPreviousItem()` wrap around menu boundaries.
 - `findMenuItem()` returns the matched item when found; otherwise `null`.
 - `selectItem()` dispatches named events for `action` entries using hyphen-case event names and closes the menu.
@@ -212,8 +213,11 @@ if (menuItem?.target === '_blank') {
 - Keep trigger button wired with `aria-haspopup="menu"`, `aria-expanded`, and `aria-controls`.
 - Keep menu container `role="menu"` and items `role="menuitem"`.
 - Use keyboard bindings for Up/Down/Home/End and Escape to maintain expected menu behavior.
+- `toggleMenu()` moves focus to the first menu item when it opens the menu, so at least one item is always keyboard-reachable regardless of whether the menu was opened by mouse click or by Enter/Space on the trigger.
 - Keep action items as real `button type="button"` elements; use anchors for navigation items.
 - Since nested entries render as a single flat list with only visual indentation to show depth, set `aria-label` on child items (depth > 0) combining `parentLabel` and `label` (for example `"API, huxDropdown(config)"`) so screen reader users get the parent/child relationship that sighted users see from indentation.
+- `role="menu"` / `role="menuitem"` model an application-style action menu, per the WAI-ARIA Authoring Practices. If a given menu is mostly page-navigation links rather than actions, consider a plain disclosure pattern (`aria-expanded` button + a list of links with no `menu`/`menuitem` roles) instead — assistive technology sets different interaction expectations for `menu` widgets (for example, arrow-key-only traversal) than for navigation link lists.
+- The demo's `border-gray-300`/`border-gray-200` trigger and menu borders fall under the 3:1 non-text contrast target on their own; this is a minor, site-wide design-system convention rather than a dropdown-specific gap, since the trigger's label, icon, and hover state provide redundant affordance that the border isn't solely responsible for. Treat a darker border as a nice-to-have, not a blocker.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- `toggleMenu()` now focuses the first menu item when it opens the menu, fixing a bug where menus opened via mouse click or Enter/Space on the trigger left every item at `tabindex="-1"` (Tab would skip past the open menu entirely — only ArrowDown/ArrowUp previously set focus correctly).
- Removed the `x-on:mouseenter` handlers driving the roving `tabindex`/highlight in the Dropdown demo, so hovering with a mouse no longer relocates the keyboard tab stop. Visual hover highlighting is unaffected (already handled by the existing `hover:bg-gray-100` classes).
- Documented the new `toggleMenu()` focus behavior in the Behavior Contract and Accessibility Notes sections of `dropdown.mdx`, plus a note on `role="menu"` semantics for nav-heavy menus.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm check`
- [ ] Manual: open menu via mouse click, confirm Tab reaches a menu item
- [ ] Manual: open menu via Enter/Space on trigger, confirm focus lands on first item
- [ ] Manual: open menu via ArrowDown/ArrowUp, confirm existing behavior unchanged
- [ ] Manual: hover over items with mouse, confirm highlight still shows without moving keyboard focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)